### PR TITLE
New views

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -2,7 +2,11 @@ import { Route, Routes } from 'react-router-dom'
 import { Paper, useTheme } from '@mui/material'
 import { ToastContainer } from 'react-toastify'
 import {
-  AboutView, FeedbackView, NotFoundView, SearchView
+  AboutView,
+  DocumentationView,
+  FeedbackView,
+  NotFoundView,
+  SearchView,
 } from './views'
 import { Drawer } from './components/drawer'
 import { Header } from './components/layout'
@@ -10,10 +14,11 @@ import { Header } from './components/layout'
 const Router = () => {
   return (
     <Routes>
-      <Route path="/"         element={ <SearchView /> } />
-      <Route path="/feedback" element={ <FeedbackView /> } />
-      <Route path="/about"    element={ <AboutView /> } />
-      <Route path="*"         element={ <NotFoundView /> } />
+      <Route path="/"               element={ <SearchView /> } />
+      <Route path="/about"          element={ <AboutView /> } />
+      <Route path="/documentation"  element={ <DocumentationView /> } />
+      <Route path="/feedback"       element={ <FeedbackView /> } />
+      <Route path="*"               element={ <NotFoundView /> } />
     </Routes>
   )
 }

--- a/src/components/layout/header.js
+++ b/src/components/layout/header.js
@@ -105,6 +105,7 @@ export const Header = () => {
               <Box sx={ navStyle }>
                 <NavLink to="/">Search</NavLink>
                 <NavLink to="/about">About</NavLink>
+                <NavLink to="/documentation">Docs</NavLink>
                 <NavLink to="/feedback">Feedback</NavLink>
               </Box>
               <StatusIndicator />

--- a/src/components/responsive-iframe.js
+++ b/src/components/responsive-iframe.js
@@ -1,0 +1,32 @@
+import PropTypes from 'prop-types'
+import { Box, useTheme } from '@mui/material'
+
+export const ResponsiveIframe = props => {
+  const theme = useTheme()
+
+  return (
+    <Box sx={{
+      border: `1px solid ${ theme.palette.primary.main }`,
+      overflow: 'hidden',
+      paddingBottom: '56.25%',
+      marginBottom: '2rem',
+      position: 'relative',
+      height: 0,
+      '& iframe': {
+        left: 0,
+        top: 0,
+        height: '100%',
+        width: '100%',
+        position: 'absolute',
+      }
+    }}
+    >
+      <iframe title={ props.title } frameBorder="0" allowFullScreen={ true } { ...props }></iframe>
+    </Box>
+  )
+}
+
+ResponsiveIframe.propTypes = {
+  title: PropTypes.string.isRequired,
+  src: PropTypes.string.isRequired,
+}

--- a/src/components/responsive-iframe.js
+++ b/src/components/responsive-iframe.js
@@ -8,10 +8,9 @@ export const ResponsiveIframe = props => {
     <Box sx={{
       border: `1px solid ${ theme.palette.primary.main }`,
       overflow: 'hidden',
-      paddingBottom: '56.25%',
+      aspectRatio: '16 / 9',
       marginBottom: '2rem',
       position: 'relative',
-      height: 0,
       '& iframe': {
         left: 0,
         top: 0,

--- a/src/views/about.js
+++ b/src/views/about.js
@@ -1,91 +1,9 @@
-import PropTypes from 'prop-types'
-import { Box, Container, Skeleton, Typography, useTheme } from '@mui/material'
-import {
-  AddCircle as TermSelectedIcon,
-  RemoveCircle as TermUnselectedIcon,
-  Circle as TermNeutralIcon,
-} from '@mui/icons-material'
-import { useAppContext } from '../context'
-import { useOntology } from '../components/ontology'
+import { Container, Typography } from '@mui/material'
 import { Link } from '../components/link'
-
-// screenshots
-import addConceptImageLight from '../images/screenshots/add-concept-light.png'
-import addConceptImageDark from '../images/screenshots/add-concept-dark.png'
-import rawQueryImageLight from '../images/screenshots/raw-query-light.png'
-import rawQueryImageDark from '../images/screenshots/raw-query-dark.png'
-import resultsImageLight from '../images/screenshots/results-light.png'
-import resultsImageDark from '../images/screenshots/results-dark.png'
-
-const screenshots = {
-  addConcept: {
-    light: addConceptImageLight,
-    dark: addConceptImageDark,
-  },
-  rawQuery: {
-    light: rawQueryImageLight,
-    dark: rawQueryImageDark,
-  },
-  results: {
-    light: resultsImageLight,
-    dark: resultsImageDark,
-  },
-}
-
-const MediaPlaceholder = ({ width, height, sx }) => {
-  return (
-    <Skeleton
-      variant="rectangular" height={ height } width={ width }
-      sx={{ mx: 'auto', my: 5, ...sx }}
-    />
-  )
-}
-
-MediaPlaceholder.propTypes = {
-  height: PropTypes.number.isRequired,
-  width: PropTypes.number.isRequired,
-  sx: PropTypes.object,
-}
-
-MediaPlaceholder.defaultProps = {
-  height: 360,
-  width: 480,
-}
-
-//
-
-const Screenshot = ({ imageSrc, height }) => {
-  const theme = useTheme()
-  return (
-    <Box sx={{
-      height: height,
-      my: 4,
-      display: 'flex',
-      justifyContent: "center",
-      alignItems: "center",
-      img: {
-        height: height,
-        border: `2px solid ${ theme.palette.background.default }`,
-      }
-    }}><img src={ imageSrc } /></Box>
-  )
-}
-
-Screenshot.propTypes = {
-  imageSrc: PropTypes.string.isRequired,
-  height: PropTypes.string,
-}
-
-Screenshot.defaultProps = {
-  height: '360px',
-}
 
 //
 
 export const AboutView = () => {
-  const ontology = useOntology()
-  const { settings } = useAppContext()
-
   return (
     <Container maxWidth="md">
       <Typography variant="h4" component="h1" align="center">
@@ -95,100 +13,32 @@ export const AboutView = () => {
       <br />
 
       <Typography variant="h5" component="h2">Purpose</Typography>
-      <Typography paragraph>
-        to help user get data details to come.
-        Est magna sit nisi labore aute nostrud anim irure consequat fugiat cupidatat do proident aliquip occaecat ex sint dolore.
-        Excepteur excepteur sed minim labore eu tempor ad irure aliqua nostrud.
-        Id irure reprehenderit est dolor officia minim minim amet sint minim laborum ea proident.
-      </Typography>
 
       <Typography paragraph>
-        Ut ea est sed nulla duis et reprehenderit nostrud enim excepteur adipisicing enim labore voluptate minim.
-        Dolore excepteur minim cupidatat eiusmod dolor nostrud reprehenderit duis do ex exercitation dolor sint amet cillum.
-        Esse in fugiat aliquip veniam eu sit dolore culpa excepteur nulla anim in adipisicing nostrud aute ut cillum in.
+        The scope of this prototype beta release is for searching for papers
+        describing neuroimaging studies on schizophrenia and addiction, by
+        building a query composed of concepts included in the NeuroBridge ontology. 
       </Typography>
 
-      <br />
-
-      <Typography variant="h5" component="h2">About the Data</Typography>
-      <Typography paragraph>
-        Currently, 356 PubMed Central publications are indexed and available
-        to search with NeuroBridge.
-        The available publications are those having imaging data dn dealing with
-        to do with schizophrenia and substance abuse that have imaging data.
-        They are all written in English and have been published within the last five years.
-        This interface is currently using our ontology version <em>{ ontology.meta.version }</em>.
-      </Typography>
+      <Typography variant="h5" component="h2">The Data</Typography>
 
       <Typography paragraph>
-        { ontology.meta.comment }
+        Currently, 356 PubMed Central publications are indexed and available to
+        search with NeuroBridge. The available publications are those documenting
+        studies of schizophrenia and substance abuse that contain information on
+        neuroimaging data. The publications have been published between 2017 and 2021. 
       </Typography>
+
+      <Typography variant="h5" component="h2">The NeuroBridge Ontology</Typography>
 
       <Typography paragraph>
-        { ontology.meta.editorialNote }
+        The NeuroBridge ontology extends the W3C PROV and ProvCaRe ontologies
+        with terms from the SchizConnect project aligned and merged into the
+        original class structure of the ProvCaRe ontology. The ProvCaRe ontology
+        was developed as part of NIH BD2K Data Provenance project.
+        The NeuroBridge ontology is available
+        on <Link to="https://github.com/NeuroBridge/">GitHub</Link>.
       </Typography>
-
-      <br />
-
-      <Typography variant="h5" component="h2">Using the Search Portal</Typography>
-
-      <Typography paragraph>
-        Because the goal is to search for publications, this purpose of this interface
-        revolves around building a query from concepts in the NeuroBridge ontology.
-        The first step to building a query is to add concepts to the query builder with
-        the &ldquo;<span style={{ whiteSpace: 'nowrap' }}>+ Add Concept</span>&rdquo; button.
-        Each concept defines an induced subtree rooted at that concept.
-        Adding a concept to the query builder makes its descendant concepts available
-        for use in the query construction.
-      </Typography>
-
-      <Screenshot imageSrc={ screenshots.addConcept[settings.color.mode] } />
-
-      <Typography paragraph sx={{
-        '& .MuiSvgIcon-root': {
-          transform: 'translateY(4px)',
-        },
-      }}>
-        Each concept in the query builder can have one of three states, and
-        clicking a term toggles between the possible states and an icon
-        indicates the concept&apos;s present state.
-        The plus <TermSelectedIcon fontSize="small" sx={{ color: 'concept.positive' }} /> icon
-        indicates that a term is present in the query.
-        The minus <TermUnselectedIcon fontSize="small" sx={{ color: 'concept.negative' }} /> icon
-        indicates that a term is present, but negated, in the query.
-        (<em>i.e.</em>, <code>NOT Schizophrenia</code>).
-        A term is left out of the query completely when it shows
-        the neutral <TermNeutralIcon fontSize="small" sx={{ color: 'concept.neutral' }} /> icon.
-      </Typography>
-
-      <Typography paragraph>
-        Holding Ctrl/⌘ while clicking a term will toggle that term&apos;s
-        descendants&apos; states to match that of the clicked term.
-      </Typography>
-    
-      <Typography paragraph>
-        Configuration options and the raw query.
-        Dolor in tempor sed magna nulla tempor aliquip fugiat excepteur cupidatat ullamco do.
-        Occaecat ut dolore veniam commodo mollit dolore proident mollit dolore excepteur cillum tempor.
-        Excepteur consequat nulla reprehenderit sunt in cillum sunt minim minim qui et non sit enim ullamco velit officia.
-      </Typography>
-
-      <Screenshot imageSrc={ screenshots.rawQuery[settings.color.mode] } />
-
-      <Typography paragraph>
-        Elit nostrud in laborum deserunt id ullamco proident elit dolore quis.
-        Lorem ipsum ut velit irure veniam elit adipisicing exercitation elit esse excepteur fugiat voluptate duis sunt proident.
-      </Typography>
-
-      <Typography paragraph>
-        Results are retrieved from two sources: the NeuroBridge API
-        and <Link to="https://neuroquery.org/">NeuroQuery</Link>.
-        Results are grouped by their source and contain links to the
-        corresponding articles in PubMed or PubMed Central.
-        Results can be selected for export.
-      </Typography>
-
-      <Screenshot imageSrc={ screenshots.results[settings.color.mode] } />
 
     </Container>
   )

--- a/src/views/documentation.js
+++ b/src/views/documentation.js
@@ -1,0 +1,11 @@
+import { Container } from '@mui/material'
+
+//
+
+export const DocumentationView = () => {
+  return (
+    <Container maxWidth="md">
+      Documentation
+    </Container>
+  )
+}

--- a/src/views/documentation.js
+++ b/src/views/documentation.js
@@ -7,6 +7,8 @@ export const DocumentationView = () => {
     <Container maxWidth="md">
       <Typography variant="h4" component="h1">Documentation</Typography>
 
+      <br />
+
       <Typography variant="h5" component="h2">
         Using the Search Portal
       </Typography>
@@ -26,7 +28,11 @@ export const DocumentationView = () => {
         revolves around building a query from concepts in the NeuroBridge ontology. 
       </Typography>
 
-      <br/><br/>[screenshot/video]<br/><br/><br/><br/>
+      <iframe
+        width="600px"
+        height="400px"
+        src="https://drive.google.com/file/d/1dLBjSspmTjzP9rqXdrNu2ZcoOXwWONvr/preview"
+      ></iframe>
 
       <Typography paragraph>
         The first step to building a query is to add concepts to the query builder with
@@ -43,7 +49,11 @@ export const DocumentationView = () => {
         Configuration Options & Viewing the Raw Query
       </Typography>
 
-      <br/><br/>[screenshot/video]<br/><br/><br/><br/>
+      <iframe
+        width="600px"
+        height="400px"
+        src="https://drive.google.com/file/d/1UxC_PioqeFyWYy5-DznT1hLwpWLZ8Wte/preview"
+      ></iframe>
   
       <Typography variant="h5" component="h2">
         Results
@@ -53,7 +63,11 @@ export const DocumentationView = () => {
         Additionally, changing the state of a concept also changes the states of its descendant concepts to match.
       </Typography>
   
-      <br/><br/>[screenshot/video]<br/><br/><br/><br/>
+      <iframe
+        width="600px"
+        height="400px"
+        src="https://drive.google.com/file/d/1FbZPj1L_NbJ57KsIfkgIDlAB9N-Md1UN/preview"
+      ></iframe>
 
     </Container>
   )

--- a/src/views/documentation.js
+++ b/src/views/documentation.js
@@ -1,4 +1,5 @@
 import { Container, Typography } from '@mui/material'
+import { ResponsiveIframe } from '../components/responsive-iframe'
 
 //
 
@@ -28,11 +29,9 @@ export const DocumentationView = () => {
         revolves around building a query from concepts in the NeuroBridge ontology. 
       </Typography>
 
-      <iframe
-        width="600px"
-        height="400px"
+      <ResponsiveIframe
         src="https://drive.google.com/file/d/1dLBjSspmTjzP9rqXdrNu2ZcoOXwWONvr/preview"
-      ></iframe>
+      />
 
       <Typography paragraph>
         The first step to building a query is to add concepts to the query builder with
@@ -49,11 +48,9 @@ export const DocumentationView = () => {
         Configuration Options & Viewing the Raw Query
       </Typography>
 
-      <iframe
-        width="600px"
-        height="400px"
+      <ResponsiveIframe
         src="https://drive.google.com/file/d/1UxC_PioqeFyWYy5-DznT1hLwpWLZ8Wte/preview"
-      ></iframe>
+      />
   
       <Typography variant="h5" component="h2">
         Results
@@ -63,11 +60,9 @@ export const DocumentationView = () => {
         Additionally, changing the state of a concept also changes the states of its descendant concepts to match.
       </Typography>
   
-      <iframe
-        width="600px"
-        height="400px"
+      <ResponsiveIframe
         src="https://drive.google.com/file/d/1FbZPj1L_NbJ57KsIfkgIDlAB9N-Md1UN/preview"
-      ></iframe>
+      />
 
     </Container>
   )

--- a/src/views/documentation.js
+++ b/src/views/documentation.js
@@ -1,11 +1,60 @@
-import { Container } from '@mui/material'
+import { Container, Typography } from '@mui/material'
 
 //
 
 export const DocumentationView = () => {
   return (
     <Container maxWidth="md">
-      Documentation
+      <Typography variant="h4" component="h1">Documentation</Typography>
+
+      <Typography variant="h5" component="h2">
+        Using the Search Portal
+      </Typography>
+
+      <Typography paragraph>
+        Results are retrieved from two sources: PubMed Central via (the NeuroBridge API) and [NeuroQuery](https://neuroquery.org/).
+        Results are grouped by their source and contain links to the
+        corresponding articles.
+      </Typography>
+
+      <Typography variant="h5" component="h2">
+        Building a Query
+      </Typography>
+
+      <Typography paragraph>
+        Because the goal is to search for publications, this purpose of this interface
+        revolves around building a query from concepts in the NeuroBridge ontology. 
+      </Typography>
+
+      <br/><br/>[screenshot/video]<br/><br/><br/><br/>
+
+      <Typography paragraph>
+        The first step to building a query is to add concepts to the query builder with
+        the &ldquo;+ Add Concept&rdquo; button.
+        Each concept defines an induced subtree rooted at that concept.
+        Adding a concept to the query builder makes its descendant concepts available for use in the query construction.
+      </Typography>
+
+      <Typography paragraph>
+        Each concept in the query builder can have one of two states&mdash;either it is in the query or not. Clicking a concept toggles between the two states, and an icon indicates the concept&apos;s present state.
+      </Typography>
+
+      <Typography variant="h5" component="h2">
+        Configuration Options & Viewing the Raw Query
+      </Typography>
+
+      <br/><br/>[screenshot/video]<br/><br/><br/><br/>
+  
+      <Typography variant="h5" component="h2">
+        Results
+      </Typography>
+
+      <Typography paragraph>
+        Additionally, changing the state of a concept also changes the states of its descendant concepts to match.
+      </Typography>
+  
+      <br/><br/>[screenshot/video]<br/><br/><br/><br/>
+
     </Container>
   )
 }

--- a/src/views/documentation.js
+++ b/src/views/documentation.js
@@ -1,4 +1,5 @@
 import { Container, Typography } from '@mui/material'
+import { Link } from '../components/link'
 import { ResponsiveIframe } from '../components/responsive-iframe'
 
 //
@@ -15,7 +16,8 @@ export const DocumentationView = () => {
       </Typography>
 
       <Typography paragraph>
-        Results are retrieved from two sources: PubMed Central via (the NeuroBridge API) and [NeuroQuery](https://neuroquery.org/).
+        Results are retrieved from two sources: PubMed Central, via our API,{' '}
+        <Link to="https://neuroquery.org/">NeuroQuery</Link>.
         Results are grouped by their source and contain links to the
         corresponding articles.
       </Typography>
@@ -25,13 +27,8 @@ export const DocumentationView = () => {
       </Typography>
 
       <Typography paragraph>
-        Because the goal is to search for publications, this purpose of this interface
-        revolves around building a query from concepts in the NeuroBridge ontology. 
+        The goal of this tool is to build a query from concepts in the NeuroBridge ontology. 
       </Typography>
-
-      <ResponsiveIframe
-        src="https://drive.google.com/file/d/1dLBjSspmTjzP9rqXdrNu2ZcoOXwWONvr/preview"
-      />
 
       <Typography paragraph>
         The first step to building a query is to add concepts to the query builder with
@@ -40,29 +37,40 @@ export const DocumentationView = () => {
         Adding a concept to the query builder makes its descendant concepts available for use in the query construction.
       </Typography>
 
-      <Typography paragraph>
-        Each concept in the query builder can have one of two states&mdash;either it is in the query or not. Clicking a concept toggles between the two states, and an icon indicates the concept&apos;s present state.
-      </Typography>
+      <ResponsiveIframe
+        src="https://drive.google.com/file/d/1FbZPj1L_NbJ57KsIfkgIDlAB9N-Md1UN/preview"
+      />
 
       <Typography variant="h5" component="h2">
         Configuration Options & Viewing the Raw Query
       </Typography>
 
+      <Typography paragraph>
+        Each concept in the query builder can have one of two states&mdash;either it is in the query or not.
+        Clicking a concept toggles between the two states, and an icon indicates the concept&apos;s present state.
+        Additionally, changing the state of a concept also changes the states of its descendant concepts to match.
+      </Typography>
+
       <ResponsiveIframe
         src="https://drive.google.com/file/d/1UxC_PioqeFyWYy5-DznT1hLwpWLZ8Wte/preview"
       />
+
+      <Typography paragraph>
+        Use the &ldquo;View/Hide Query&rdquo; button to toggle visibility of the raw query that will be sent to the NeuroBridge API.
+        The boolean logic within the query can be chaanged in the option modal, which can be opened with the &ldquo;Options&rdquo; button.
+      </Typography>
   
+      <ResponsiveIframe
+        src="https://drive.google.com/file/d/1dLBjSspmTjzP9rqXdrNu2ZcoOXwWONvr/preview"
+      />
+
       <Typography variant="h5" component="h2">
         Results
       </Typography>
 
       <Typography paragraph>
-        Additionally, changing the state of a concept also changes the states of its descendant concepts to match.
+        Results are displayed in different tabs based on their source.
       </Typography>
-  
-      <ResponsiveIframe
-        src="https://drive.google.com/file/d/1FbZPj1L_NbJ57KsIfkgIDlAB9N-Md1UN/preview"
-      />
 
     </Container>
   )

--- a/src/views/index.js
+++ b/src/views/index.js
@@ -1,4 +1,5 @@
 export * from './about'
+export * from './documentation'
 export * from './feedback'
 export * from './not-found'
 export * from './search'


### PR DESCRIPTION
this PR restructures the About view and adds a new Documentation view.
- see #33 for the About view content
- the Documentation view is intended (#50) to give a place to describe how to use the search portal, with text and videos.
  + the content hasn't been written yet, but some boilerplate comes along with this PR.
  + the first draft of the videos are also in place. i could see some reworking of those, though, as (1) the UI has already changed a bit since these were recorded and (2) there is likely a better way to split up the content between videos. will track with separate issue.

along with this comes a new ResponsiveIframe React component to help render the embedded videos consistently and nicely.

future: consider pulling all this static content into markdown files