### PR TITLE
Feature/health check

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+  "liveServer.settings.port": 5501
+}

--- a/src/components/layout/header.js
+++ b/src/components/layout/header.js
@@ -13,6 +13,7 @@ import { Link } from '../link'
 import { useMatch, useResolvedPath } from 'react-router-dom'
 import { useDrawer } from '../drawer'
 import { useAppContext } from '../../context'
+import { StatusIndicator } from '../status-indicator'
 
 const HideOnScroll = ({ children }) => {
   const trigger = useScrollTrigger()
@@ -106,6 +107,7 @@ export const Header = () => {
                 <NavLink to="/about">About</NavLink>
                 <NavLink to="/feedback">Feedback</NavLink>
               </Box>
+              <StatusIndicator />
               <Tooltip title={ `Switch to ${ settings.color.mode === settings.color.modes.light ? 'dark' : 'light' } mode` } placement="bottom">
                 <IconButton onClick={ settings.color.toggleMode } color="primary">
                   {

--- a/src/components/status-indicator.js
+++ b/src/components/status-indicator.js
@@ -1,0 +1,74 @@
+import { Circle } from "@mui/icons-material";
+import { IconButton, Paper, Popover, Tooltip, Typography } from "@mui/material";
+import { styled } from "@mui/system";
+import { useState } from "react";
+
+const PopoverPaper = styled(Paper)(({theme}) => ({
+  padding: theme.spacing(2),
+  filter: `drop-shadow(0px 0px 6px rgba(0, 0, 0, 0.3))`,
+  backgroundImage: 'linear-gradient(rgba(255, 255, 255, 0.16), rgba(255, 255, 255, 0.16))',
+
+  position: 'relative',
+  '&::before': {
+    content: '""',
+    display: 'block',
+    position: 'absolute',
+    top: '-15px',
+    left: '0',
+    right: '0',
+    margin: '0 auto',
+    clipPath: "path('M 0 15 L 10 0 L 20 15 Z')",
+    width: '20px',
+    height: '15px',
+    backgroundColor: theme.palette.background.paper,
+    backgroundImage: 'linear-gradient(rgba(255, 255, 255, 0.16), rgba(255, 255, 255, 0.16))',
+  }
+}));
+
+export const StatusIndicator = () => {
+  const [anchorEl, setAnchorEl] = useState(null);
+
+  const handleClick = (event) => {
+    setAnchorEl(event.currentTarget);
+  };
+
+  const handleClose = () => {
+    setAnchorEl(null);
+  };
+
+  const open = Boolean(anchorEl);
+  const id = open ? "simple-popover" : undefined;
+
+  return (
+    <>
+      <Tooltip placement="bottom" title="All services are operational">
+        <IconButton color="success" onClick={handleClick}>
+          <Circle fontSize="xs" />
+        </IconButton>
+      </Tooltip>
+      <Popover
+        id={id}
+        open={open}
+        anchorEl={anchorEl}
+        onClose={handleClose}
+        anchorOrigin={{
+          vertical: "bottom",
+          horizontal: "center",
+        }}
+        transformOrigin={{
+          vertical: 'top',
+          horizontal: 'center',
+        }}
+        sx={{ marginTop: '15px',
+        '& .MuiPopover-paper': {overflowY: 'visible', overflowX: 'visible'} }}
+        PaperProps={{ style: {boxShadow: 'none'}}}
+      >
+        <PopoverPaper>
+          <Typography>Service 1: Operational</Typography>
+          <Typography>Service 2: Operational</Typography>
+          <Typography>Service 3: Operational</Typography>
+        </PopoverPaper>
+      </Popover>
+    </>
+  );
+};

--- a/src/components/status-indicator.js
+++ b/src/components/status-indicator.js
@@ -4,9 +4,11 @@ import { styled } from "@mui/system";
 import { useState } from "react";
 
 const PopoverPaper = styled(Paper)(({theme}) => ({
+  '--gradient-overlay': 'linear-gradient(rgba(255, 255, 255, 0.16), rgba(255, 255, 255, 0.16))',
+  
   padding: theme.spacing(2),
   filter: `drop-shadow(0px 0px 6px rgba(0, 0, 0, 0.3))`,
-  backgroundImage: 'linear-gradient(rgba(255, 255, 255, 0.16), rgba(255, 255, 255, 0.16))',
+  backgroundImage: 'var(--gradient-overlay)',
 
   position: 'relative',
   '&::before': {
@@ -21,7 +23,7 @@ const PopoverPaper = styled(Paper)(({theme}) => ({
     width: '20px',
     height: '15px',
     backgroundColor: theme.palette.background.paper,
-    backgroundImage: 'linear-gradient(rgba(255, 255, 255, 0.16), rgba(255, 255, 255, 0.16))',
+    backgroundImage: 'var(--gradient-overlay)',
   }
 }));
 

--- a/src/components/status-indicator.js
+++ b/src/components/status-indicator.js
@@ -190,8 +190,9 @@ export const StatusIndicator = () => {
                     fontSize: "15px",
                   }}
                 >
-                  {status === "loading" && <CircularProgress size="15px" />}
-                  {status !== "loading" && (
+                  {status === "loading" ? (
+                    <CircularProgress size="15px" />
+                  ) : (
                     <Circle fontSize="inherit" color={status} />
                   )}
                 </Box>

--- a/src/components/status-indicator.js
+++ b/src/components/status-indicator.js
@@ -95,7 +95,8 @@ export const StatusIndicator = () => {
         }))
         .then((serviceStatus) =>
           setStatuses((prev) => ({ ...prev, ...serviceStatus }))
-        );
+        )
+        .catch(() => setStatuses((prev) => ({ ...prev, [name]: "error" })));
     });
   };
 
@@ -118,15 +119,17 @@ export const StatusIndicator = () => {
     return "All services are operational";
   };
 
-  const iconButtonColor = numberOfErrors > 0 ? 'error' : 'success';
+  const iconButtonColor = numberOfErrors > 0 ? "error" : "success";
 
   return (
     <>
       <Tooltip placement="bottom" title={tooltipText()}>
         <IconButton color={iconButtonColor} onClick={handleClick}>
-          {Object.values(statuses).some((status) => status === "loading")
-            ? <CircularProgress size='24px'/>
-            : <Circle fontSize="xs" /> }
+          {Object.values(statuses).some((status) => status === "loading") ? (
+            <CircularProgress size="24px" />
+          ) : (
+            <Circle fontSize="xs" />
+          )}
         </IconButton>
       </Tooltip>
 

--- a/src/components/status-indicator.js
+++ b/src/components/status-indicator.js
@@ -1,34 +1,73 @@
-import { Circle } from "@mui/icons-material";
-import { IconButton, Paper, Popover, Tooltip, Typography } from "@mui/material";
+import { Circle, Refresh } from "@mui/icons-material";
+import {
+  Box,
+  CircularProgress,
+  Divider,
+  IconButton,
+  Paper,
+  Popover,
+  Tooltip,
+  Typography,
+} from "@mui/material";
 import { styled } from "@mui/system";
-import { useState } from "react";
+import { useEffect, useState } from "react";
 
-const PopoverPaper = styled(Paper)(({theme}) => ({
-  '--gradient-overlay': 'linear-gradient(rgba(255, 255, 255, 0.16), rgba(255, 255, 255, 0.16))',
-  
+const STATUS_URLS = [
+  {
+    name: "NeuroQuery",
+    url: "https://neurobridges.renci.org:13374/query?searchTerms=abstinence",
+    method: "GET",
+  },
+  {
+    name: "NeuroBridge",
+    url: "https://neurobridges-ml.renci.org/nb_translator",
+    method: "POST",
+    body: {
+      query: {
+        expression: {
+          OR: ["Abstinent"],
+        },
+        max_res: 100,
+      },
+    },
+  },
+  {
+    name: "NB-NQ Translator",
+    url: "https://neurobridges.apps.renci.org/healthz",
+    method: "GET",
+  },
+];
+
+const PopoverPaper = styled(Paper)(({ theme }) => ({
+  "--gradient-overlay":
+    "linear-gradient(rgba(255, 255, 255, 0.16), rgba(255, 255, 255, 0.16))",
+
   padding: theme.spacing(2),
   filter: `drop-shadow(0px 0px 6px rgba(0, 0, 0, 0.3))`,
-  backgroundImage: 'var(--gradient-overlay)',
+  backgroundImage: "var(--gradient-overlay)",
 
-  position: 'relative',
-  '&::before': {
+  position: "relative",
+  "&::before": {
     content: '""',
-    display: 'block',
-    position: 'absolute',
-    top: '-15px',
-    left: '0',
-    right: '0',
-    margin: '0 auto',
+    display: "block",
+    position: "absolute",
+    top: "-15px",
+    left: "0",
+    right: "0",
+    margin: "0 auto",
     clipPath: "path('M 0 15 L 10 0 L 20 15 Z')",
-    width: '20px',
-    height: '15px',
+    width: "20px",
+    height: "15px",
     backgroundColor: theme.palette.background.paper,
-    backgroundImage: 'var(--gradient-overlay)',
-  }
+    backgroundImage: "var(--gradient-overlay)",
+  },
 }));
 
 export const StatusIndicator = () => {
   const [anchorEl, setAnchorEl] = useState(null);
+  const [statuses, setStatuses] = useState(
+    STATUS_URLS.reduce((acc, curr) => ({ ...acc, [curr.name]: "loading" }), {})
+  );
 
   const handleClick = (event) => {
     setAnchorEl(event.currentTarget);
@@ -41,13 +80,56 @@ export const StatusIndicator = () => {
   const open = Boolean(anchorEl);
   const id = open ? "simple-popover" : undefined;
 
+  const refreshStatuses = () => {
+    setStatuses(
+      STATUS_URLS.reduce(
+        (acc, curr) => ({ ...acc, [curr.name]: "loading" }),
+        {}
+      )
+    );
+
+    STATUS_URLS.forEach(({ name, url, method, body }) => {
+      fetch(url, { method, body: JSON.stringify(body) })
+        .then((response) => ({
+          [name]: response.status === 200 ? "success" : "error",
+        }))
+        .then((serviceStatus) =>
+          setStatuses((prev) => ({ ...prev, ...serviceStatus }))
+        );
+    });
+  };
+
+  useEffect(() => {
+    refreshStatuses();
+  }, []);
+
+  const numberOfErrors = Object.values(statuses).reduce(
+    (sum, currentStatus) => (currentStatus === "error" ? sum + 1 : sum),
+    0
+  );
+
+  const tooltipText = () => {
+    if (numberOfErrors > 0) {
+      return `${numberOfErrors} service${numberOfErrors > 1 ? "s" : ""} down`;
+    }
+    if (Object.values(statuses).some((status) => status === "loading")) {
+      return "Checking services...";
+    }
+    return "All services are operational";
+  };
+
+  const iconButtonColor = numberOfErrors > 0 ? 'error' : 'success';
+
   return (
     <>
-      <Tooltip placement="bottom" title="All services are operational">
-        <IconButton color="success" onClick={handleClick}>
-          <Circle fontSize="xs" />
+      <Tooltip placement="bottom" title={tooltipText()}>
+        <IconButton color={iconButtonColor} onClick={handleClick}>
+          {Object.values(statuses).some((status) => status === "loading")
+            ? <CircularProgress size='24px'/>
+            : <Circle fontSize="xs" /> }
         </IconButton>
       </Tooltip>
+
       <Popover
         id={id}
         open={open}
@@ -58,17 +140,61 @@ export const StatusIndicator = () => {
           horizontal: "center",
         }}
         transformOrigin={{
-          vertical: 'top',
-          horizontal: 'center',
+          vertical: "top",
+          horizontal: "center",
         }}
-        sx={{ marginTop: '15px',
-        '& .MuiPopover-paper': {overflowY: 'visible', overflowX: 'visible'} }}
-        PaperProps={{ style: {boxShadow: 'none'}}}
+        sx={{
+          marginTop: "15px",
+          "& .MuiPopover-paper": { overflowY: "visible", overflowX: "visible" },
+        }}
+        PaperProps={{ style: { boxShadow: "none" } }}
       >
         <PopoverPaper>
-          <Typography>Service 1: Operational</Typography>
-          <Typography>Service 2: Operational</Typography>
-          <Typography>Service 3: Operational</Typography>
+          <Box
+            sx={{
+              display: "flex",
+              alignItems: "center",
+              justifyContent: "space-between",
+            }}
+          >
+            <Typography variant="h6" component="h3">
+              Status
+            </Typography>
+            <IconButton size="small" onClick={refreshStatuses}>
+              <Refresh />
+            </IconButton>
+          </Box>
+          <Divider sx={{ margin: "6px 0 10px 0" }} />
+          <Box sx={{ display: "flex", flexDirection: "column", gap: "4px" }}>
+            {Object.entries(statuses).map(([name, status], index) => (
+              <Box
+                key={index}
+                sx={{
+                  display: "flex",
+                  alignItems: "center",
+                  justifyContent: "space-between",
+                  gap: "3ch",
+                }}
+              >
+                <Typography variant="body1">{name}</Typography>
+                <Box
+                  sx={{
+                    width: "24px",
+                    height: "24px",
+                    display: "flex",
+                    justifyContent: "center",
+                    alignItems: "center",
+                    fontSize: "15px",
+                  }}
+                >
+                  {status === "loading" && <CircularProgress size="15px" />}
+                  {status !== "loading" && (
+                    <Circle fontSize="inherit" color={status} />
+                  )}
+                </Box>
+              </Box>
+            ))}
+          </Box>
         </PopoverPaper>
       </Popover>
     </>


### PR DESCRIPTION
Closes #59 

---

https://user-images.githubusercontent.com/16181779/226390483-1b9db005-08fb-4640-88f1-4632338ede59.mov

---

I'm doing dummy queries as a for NB and NQ to check that the service is up, but we may want to have a dedicated `/healthz` endpoint like the NB-NQ translator for this purpose:

```ts
const STATUS_URLS = [
  {
    name: "NeuroQuery",
    url: "https://neurobridges.renci.org:13374/query?searchTerms=abstinence",
    method: "GET",
  },
  {
    name: "NeuroBridge",
    url: "https://neurobridges-ml.renci.org/nb_translator",
    method: "POST",
    body: {
      query: {
        expression: {
          OR: ["Abstinent"],
        },
        max_res: 100,
      },
    },
  },
  {
    name: "NB-NQ Translator",
    url: "https://neurobridges.apps.renci.org/healthz",
    method: "GET",
  },
];
```

---

 Error state:
![image](https://user-images.githubusercontent.com/16181779/226390794-d36fef93-e4d7-41e3-afba-1e6a472b853a.png)
