### PR TITLE
Fix "There was an error communicating with the NeuroQuery API" bug

### DIFF
--- a/src/components/search/context.js
+++ b/src/components/search/context.js
@@ -83,6 +83,8 @@ export const SearchProvider = ({ children }) => {
   };
 
   const nqFetchResults = async (selectedTerms) => {
+    if(selectedTerms?.length === 0) return [];
+    
     const selectedTermsQueryString = selectedTerms.join(',');
 
     const translatedTerms = await axios.get(process.env.NB_NQ_TRANSLATOR_URL, { params: { searchTerms: selectedTermsQueryString } })
@@ -102,7 +104,9 @@ export const SearchProvider = ({ children }) => {
         console.error(error)
         return []
       })
-    
+
+    if(translatedTerms?.length === 0) return [];
+
     return await axios.get(process.env.NQ_API_URL, { params: { searchTerms: translatedTerms } })
       .then(({ data }) => {
         if (!data?.data) {


### PR DESCRIPTION
Adds a check to skip the fetch request if the NB-to-NQ translator API couldn't translate anything.