### PR TITLE
fix subroute matching

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,4 +23,5 @@ RUN npm run build
 ########################
 FROM bitnami/nginx:latest
 COPY --from=builder /src/dist /opt/bitnami/nginx/html/
+COPY ./server.conf /opt/bitnami/nginx/conf/server_blocks/server.conf
 CMD ["nginx", "-g", "daemon off;"]

--- a/server.conf
+++ b/server.conf
@@ -1,0 +1,24 @@
+# This config handles non-root path routing
+# for a single-page application, telling
+# Nginx to fallback to the index.html file.
+
+server {
+    listen  8080;
+
+    include  "/opt/bitnami/nginx/conf/bitnami/*.conf";
+
+    root /app;
+
+    index index.htm index.html;
+
+    location / {
+      try_files $uri /index.html;
+    }
+
+    location /status {
+        stub_status on;
+        access_log   off;
+        allow 127.0.0.1;
+        deny all;
+    }
+}

--- a/server.conf
+++ b/server.conf
@@ -5,20 +5,9 @@
 server {
     listen  8080;
 
-    include  "/opt/bitnami/nginx/conf/bitnami/*.conf";
-
     root /app;
-
-    index index.htm index.html;
 
     location / {
       try_files $uri /index.html;
-    }
-
-    location /status {
-        stub_status on;
-        access_log   off;
-        allow 127.0.0.1;
-        deny all;
     }
 }

--- a/server.conf
+++ b/server.conf
@@ -1,6 +1,7 @@
 # This config handles non-root path routing
 # for a single-page application, telling
 # Nginx to fallback to the index.html file.
+# For more info, see https://hub.docker.com/r/bitnami/nginx
 
 server {
     listen  8080;


### PR DESCRIPTION
This PR adds an NGINX configuration file, `server.conf`, that tells NGINX to fallback to base `index.html` so JS can handle client-side routing.

A directive has been added to the Dockerfile to copy this file into the location specified in the [base image notes](https://hub.docker.com/r/bitnami/nginx) on DockerHub.